### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [2.5.2] - 2020-06-20
+
+### Fixed
+
+- fix(Selector): Mark selector dependencies to be read again and return same promise if selector read is still in progress when read is called again (Probable scenario when cleanCache and read are called while previous selector read method is still in progress)
+
 ## [2.5.1] - 2020-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.5.2] - 2020-06-20
 
 ### Fixed
-
 - fix(Selector): Mark selector dependencies to be read again and return same promise if selector read is still in progress when read is called again (Probable scenario when cleanCache and read are called while previous selector read method is still in progress)
 
 ## [2.5.1] - 2020-06-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/core",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/core",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Async Data Provider agnostic about data origins",
   "keywords": [
     "data",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=data-provider
 sonar.projectKey=data-provider-core
-sonar.projectVersion=2.5.1
+sonar.projectVersion=2.5.2
 
 sonar.sources=src,test
 sonar.exclusions=node_modules/**

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -167,7 +167,21 @@ class SelectorBase extends Provider {
           return Promise.reject(error);
         });
     };
-    return readAndReturn();
+    if (this._readInProgress) {
+      hasToReadAgain = true;
+      return this._readInProgress;
+    }
+
+    this._readInProgress = readAndReturn()
+      .then((result) => {
+        this._readInProgress = null;
+        return Promise.resolve(result);
+      })
+      .catch((error) => {
+        this._readInProgress = null;
+        return Promise.reject(error);
+      });
+    return this._readInProgress;
   }
 
   _cleanCaches(dependencies) {

--- a/test/selector/cache.js
+++ b/test/selector/cache.js
@@ -38,7 +38,7 @@ describe("Selector cache", () => {
             } else {
               reject(new Error());
             }
-          }, 50);
+          }, 100);
         });
       }
     };
@@ -53,6 +53,20 @@ describe("Selector cache", () => {
   afterEach(() => {
     sandbox.restore();
     providers.clear();
+  });
+
+  describe("selector cache", () => {
+    it("should not execute read method more than once if cache is cleaned while it is already reading", async () => {
+      selector.read();
+      selector.cleanCache();
+      selector.read();
+      selector.cleanCache();
+      selector.read();
+      selector.cleanCache();
+      selector.read();
+      await selector.read();
+      expect(spies.selectorRead.callCount).toEqual(1);
+    });
   });
 
   describe("without query", () => {


### PR DESCRIPTION
### Fixed
- fix(Selector): Mark selector dependencies to be read again and return same promise if selector read is still in progress when read is called again (Probable scenario when cleanCache and read are called while previous selector read method is still in progress)