### PR TITLE
Force cleaning of selectors cache when a dependency cache is cleaned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - chore(ci): Migrate from Travis CI to github actions
 - chore(deps): Support all Node.js releases that have not passed their end date
-
+- feat(events): Allow passing a new argument to events with extra details. Emit used options in the cleanCache event.
 ### Changed
+- test(mutation): Set branch name in stryker dashboard based on environment variable
 ### Fixed
+- fix(events): Pass force option also to children when cleaning caches
 ### Removed
 
 ## [2.8.1] - 2020-11-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - chore(ci): Migrate from Travis CI to github actions
 - chore(deps): Support all Node.js releases that have not passed their end date
-- feat(events): Allow passing a new argument to events with extra details. Emit used options in the cleanCache event.
 ### Changed
 - test(mutation): Set branch name in stryker dashboard based on environment variable
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - test(mutation): Set branch name in stryker dashboard based on environment variable
 ### Fixed
 - fix(events): Pass force option also to children when cleaning caches
+- fix(selector): Force cleaning of cache when a selector dependency is cleaned
 ### Removed
 
 ## [2.8.1] - 2020-11-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - fix(events): Pass force option also to children when cleaning caches
 - fix(selector): Force cleaning of cache when a selector dependency is cleaned
+- fix(providers): Allow options in providers.cleanCache method
 ### Removed
 
 ## [2.8.1] - 2020-11-27

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status][travisci-image]][travisci-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![Mutation testing badge][stryker-image]][stryker-url]
+[![Build status][build-image]][build-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![Mutation testing badge][stryker-image]][stryker-url]
 
 [![NPM dependencies][npm-dependencies-image]][npm-dependencies-url] [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com) [![Last commit][last-commit-image]][last-commit-url] [![Last release][release-image]][release-url] 
 
@@ -197,8 +197,8 @@ Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of 
 
 [coveralls-image]: https://coveralls.io/repos/github/data-provider/core/badge.svg
 [coveralls-url]: https://coveralls.io/github/data-provider/core
-[travisci-image]: https://travis-ci.com/data-provider/core.svg?branch=master
-[travisci-url]: https://travis-ci.com/data-provider/core
+[build-image]: https://github.com/data-provider/core/workflows/build/badge.svg?branch=master
+[build-url]: https://github.com/data-provider/core/actions?query=workflow%3Abuild+branch%3Amaster
 [last-commit-image]: https://img.shields.io/github/last-commit/data-provider/core.svg
 [last-commit-url]: https://github.com/data-provider/core/commits
 [license-image]: https://img.shields.io/npm/l/@data-provider/core.svg

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -50,9 +50,9 @@ class Provider {
     return eventNamespace(eventName, this._id);
   }
 
-  _emitChild(eventName, child, data) {
-    this.emit(childEventName(eventName), child, data);
-    eventEmitter.emit(this._eventNamespace(childEventName(ANY)), eventName, child, data);
+  _emitChild(eventName, child) {
+    this.emit(childEventName(eventName), child);
+    eventEmitter.emit(this._eventNamespace(childEventName(ANY)), eventName, child);
   }
 
   _dispatch(action) {
@@ -105,7 +105,7 @@ class Provider {
     // Reset cleanCacheInterval
     this._setCleanCacheInterval(this._previousCleanCacheInterval, true);
     this._cache = null;
-    this.emit(CLEAN_CACHE, null, options);
+    this.emit(CLEAN_CACHE);
     this._children.forEach((child) => child.cleanCache(options));
   }
 
@@ -208,7 +208,7 @@ class Provider {
     this._queryMethodsParsers.forEach((queryMethodParser, queryMethodKey) =>
       child.addQuery(queryMethodKey, queryMethodParser)
     );
-    child.on(ANY, (eventName, data) => this._emitChild(eventName, child, data));
+    child.on(ANY, (eventName) => this._emitChild(eventName, child));
     this._children.set(id, child);
     child._parent = this;
     return child;
@@ -260,14 +260,9 @@ class Provider {
       : this._options.initialState;
   }
 
-  emit(eventName, child, data) {
-    if (child) {
-      eventEmitter.emit(this._eventNamespace(eventName), child, data);
-      eventEmitter.emit(this._eventNamespace(ANY), eventName, child, data);
-    } else {
-      eventEmitter.emit(this._eventNamespace(eventName), data);
-      eventEmitter.emit(this._eventNamespace(ANY), eventName, data);
-    }
+  emit(eventName, child) {
+    eventEmitter.emit(this._eventNamespace(eventName), child);
+    eventEmitter.emit(this._eventNamespace(ANY), eventName, child);
   }
 
   // Methods that can be overwritten by addons

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -94,7 +94,7 @@ class SelectorBase extends Provider {
 
     const cleanCache = () => {
       dependenciesListeners.forEach((removeListener) => removeListener());
-      this.cleanCache();
+      this.cleanCache({ force: true });
     };
 
     const readDependency = (dependencyToRead, catchMethod) => {

--- a/src/providers.js
+++ b/src/providers.js
@@ -28,8 +28,8 @@ export class ProvidersHandler {
     return this;
   }
 
-  _run(method) {
-    this._providers.forEach((provider) => provider[method]());
+  _run(method, options) {
+    this._providers.forEach((provider) => provider[method](options));
     return this;
   }
 
@@ -51,8 +51,8 @@ export class ProvidersHandler {
     return this;
   }
 
-  cleanCache() {
-    return this._run("cleanCache");
+  cleanCache(options) {
+    return this._run("cleanCache", options);
   }
 
   resetState() {
@@ -170,8 +170,8 @@ export class Providers {
     return this._allProviders.config(options);
   }
 
-  cleanCache() {
-    return this._allProviders.cleanCache();
+  cleanCache(options) {
+    return this._allProviders.cleanCache(options);
   }
 
   resetState() {

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,11 +1,28 @@
-module.exports = {
+const BRANCH_NAME = process.env.BRANCH_NAME;
+const STRYKER_DASHBOARD_API_KEY = process.env.STRYKER_DASHBOARD_API_KEY;
+
+const BASE_CONFIG = {
   mutate: ["src/**/*.js"],
   packageManager: "npm",
-  dashboard: {
-    project: "github.com/data-provider/core",
-    version: "master",
+  thresholds: {
+    high: 80,
+    low: 60,
+    break: 80,
   },
   reporters: ["html", "clear-text", "progress", "dashboard"],
   testRunner: "jest",
   coverageAnalysis: "off",
 };
+
+const config = {
+  ...BASE_CONFIG,
+  dashboard:
+    BRANCH_NAME && STRYKER_DASHBOARD_API_KEY
+      ? {
+          project: "github.com/data-provider/core",
+          version: BRANCH_NAME,
+        }
+      : undefined,
+};
+
+module.exports = config;

--- a/test/provider/clean-cache-throttle.js
+++ b/test/provider/clean-cache-throttle.js
@@ -198,6 +198,20 @@ describe("Provider cleanCacheThrottle option", () => {
       expect(cleanCacheEventListener.callCount).toEqual(2);
     });
 
+    it("should emit cleanCache event if parent cleanCache is called with force option", async () => {
+      expect.assertions(2);
+      const childCleanCacheEventListener = sandbox.stub();
+      const childProvider = provider.query({ foo: "foo" });
+      childProvider.config({
+        cleanCacheThrottle: 500,
+      });
+      childProvider.on("cleanCache", childCleanCacheEventListener);
+      childProvider.cleanCache(); // This one cleans the cache
+      expect(childCleanCacheEventListener.callCount).toEqual(1);
+      provider.cleanCache({ force: true }); // throttled
+      expect(childCleanCacheEventListener.callCount).toEqual(2);
+    });
+
     it("should not emit any event more when finish throttle time after cleaning cache forced", async () => {
       expect.assertions(4);
       provider.config({

--- a/test/provider/events.js
+++ b/test/provider/events.js
@@ -253,13 +253,7 @@ describe("Provider events", () => {
       provider.on("cleanCache", spy);
       provider.cleanCache();
       expect(spy.callCount).toEqual(1);
-    });
-
-    it("should emit cleanCache options as first argument", async () => {
-      const spy = sandbox.spy();
-      provider.on("cleanCache", spy);
-      provider.cleanCache({ force: true });
-      expect(spy.getCall(0).args[0]).toEqual({ force: true });
+      expect(spy.getCall(0).args[0]).toEqual(undefined);
     });
 
     it("should emit a cleanCache event when listener is added with wildcard", async () => {
@@ -269,27 +263,12 @@ describe("Provider events", () => {
       expect(spy.getCall(0).args[0]).toEqual("cleanCache");
     });
 
-    it("should emit cleanCache options as second argument when listener is added with wildcard", async () => {
-      const spy = sandbox.spy();
-      provider.on("*", spy);
-      provider.cleanCache({ force: true });
-      expect(spy.getCall(0).args[0]).toEqual("cleanCache");
-      expect(spy.getCall(0).args[1]).toEqual({ force: true });
-    });
-
     it("should emit a child cleanCache event when child cache is clean", async () => {
       const spy = sandbox.spy();
       provider.onChild("cleanCache", spy);
       childProvider.cleanCache();
       expect(spy.callCount).toEqual(1);
-    });
-
-    it("should emit cleanCache options as second argument when child cache is clean", async () => {
-      const spy = sandbox.spy();
-      provider.onChild("cleanCache", spy);
-      childProvider.cleanCache({ force: true });
       expect(spy.getCall(0).args[0]).toEqual(childProvider);
-      expect(spy.getCall(0).args[1]).toEqual({ force: true });
     });
 
     it("should emit a child cleanCache event when parent cache is clean", async () => {
@@ -297,14 +276,7 @@ describe("Provider events", () => {
       provider.onChild("cleanCache", spy);
       provider.cleanCache();
       expect(spy.callCount).toEqual(1);
-    });
-
-    it("should emit cleanCache options as second argument when parent cache is clean", async () => {
-      const spy = sandbox.spy();
-      provider.onChild("cleanCache", spy);
-      provider.cleanCache({ force: true });
       expect(spy.getCall(0).args[0]).toEqual(childProvider);
-      expect(spy.getCall(0).args[1]).toEqual({ force: true });
     });
   });
 

--- a/test/provider/events.js
+++ b/test/provider/events.js
@@ -255,11 +255,26 @@ describe("Provider events", () => {
       expect(spy.callCount).toEqual(1);
     });
 
+    it("should emit cleanCache options as first argument", async () => {
+      const spy = sandbox.spy();
+      provider.on("cleanCache", spy);
+      provider.cleanCache({ force: true });
+      expect(spy.getCall(0).args[0]).toEqual({ force: true });
+    });
+
     it("should emit a cleanCache event when listener is added with wildcard", async () => {
       const spy = sandbox.spy();
       provider.on("*", spy);
       provider.cleanCache();
       expect(spy.getCall(0).args[0]).toEqual("cleanCache");
+    });
+
+    it("should emit cleanCache options as second argument when listener is added with wildcard", async () => {
+      const spy = sandbox.spy();
+      provider.on("*", spy);
+      provider.cleanCache({ force: true });
+      expect(spy.getCall(0).args[0]).toEqual("cleanCache");
+      expect(spy.getCall(0).args[1]).toEqual({ force: true });
     });
 
     it("should emit a child cleanCache event when child cache is clean", async () => {
@@ -269,11 +284,27 @@ describe("Provider events", () => {
       expect(spy.callCount).toEqual(1);
     });
 
+    it("should emit cleanCache options as second argument when child cache is clean", async () => {
+      const spy = sandbox.spy();
+      provider.onChild("cleanCache", spy);
+      childProvider.cleanCache({ force: true });
+      expect(spy.getCall(0).args[0]).toEqual(childProvider);
+      expect(spy.getCall(0).args[1]).toEqual({ force: true });
+    });
+
     it("should emit a child cleanCache event when parent cache is clean", async () => {
       const spy = sandbox.spy();
       provider.onChild("cleanCache", spy);
       provider.cleanCache();
       expect(spy.callCount).toEqual(1);
+    });
+
+    it("should emit cleanCache options as second argument when parent cache is clean", async () => {
+      const spy = sandbox.spy();
+      provider.onChild("cleanCache", spy);
+      provider.cleanCache({ force: true });
+      expect(spy.getCall(0).args[0]).toEqual(childProvider);
+      expect(spy.getCall(0).args[1]).toEqual({ force: true });
     });
   });
 

--- a/test/providers/cleanCache.js
+++ b/test/providers/cleanCache.js
@@ -50,6 +50,15 @@ describe("providers handler cleanCache method", () => {
       expect(fooProvider3.cleanCache.callCount).toEqual(1);
       expect(fooProvider4.cleanCache.callCount).toEqual(1);
     });
+
+    it("should pass options to providers cleanCache method", () => {
+      providers.cleanCache({ force: true });
+
+      expect(fooProvider.cleanCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider2.cleanCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider3.cleanCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider4.cleanCache.getCall(0).args[0]).toEqual({ force: true });
+    });
   });
 
   describe("when used with getById", () => {

--- a/test/selector/cache-dependencies-clean-throttle.js
+++ b/test/selector/cache-dependencies-clean-throttle.js
@@ -180,6 +180,21 @@ describe("Selector cleanCacheThrottle option", () => {
       expect(cleanCacheEventListener.callCount).toEqual(2);
     });
 
+    it("should emit cleanCache event if cleanCache is called in a dependency even when it is throttled", async () => {
+      expect.assertions(2);
+      const ownCleanCacheEventListener = sandbox.stub();
+      selector.config({
+        cleanCacheThrottle: 500,
+      });
+      selector.on("cleanCache", ownCleanCacheEventListener);
+      await selector.read();
+      selector.cleanDependenciesCache(); // This one cleans the cache
+      expect(ownCleanCacheEventListener.callCount).toEqual(1);
+      await selector.read();
+      provider.cleanCache(); // throttled
+      expect(ownCleanCacheEventListener.callCount).toEqual(2);
+    });
+
     it("should not emit any event more when finish throttle time after cleaning cache forced", async () => {
       expect.assertions(4);
       selector.config({


### PR DESCRIPTION
### Fixed
- fix(events): Pass force option also to children when cleaning caches
- fix(selector): Force cleaning of cache when a selector dependency is cleaned
- fix(providers): Allow options in providers.cleanCache method

closes #156 
