### PR TITLE
Addons base tags. Selector tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: Allow defining baseTags property in addons. Will be extended with "tags" option when instantiated for calculating provider tags. (#143)
 - feat: Add tags getter
 - feat: Add "selector" base tag to selectors (#163)
+- feat: Add `cleanDependenciesCache` method to `providers` handler (#164)
 ### Changed
 ### Fixed
 - docs(readme): Fix typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 - feat: Allow defining baseTags property in addons. Will be extended with "tags" option when instantiated for calculating provider tags. (#143)
-- feat: Add tags getter.
+- feat: Add tags getter
+- feat: Add "selector" base tag to selectors (#163)
 ### Changed
 ### Fixed
 - docs(readme): Fix typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat: Add tags getter.
 ### Changed
 ### Fixed
+- docs(readme): Fix typos
 ### Removed
 
 ## [2.8.2] - 2020-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat: Allow defining baseTags property in addons. Will be extended with "tags" option when instantiated for calculating provider tags. (#143)
+- feat: Add tags getter.
 ### Changed
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # [![Data Provider][logo]][home]
 
-> Async Data Provider. Powered by Redux. Agnostic about data origins. Framework agnostic.
+> Async Data Provider. Powered by Redux. Agnostic about data origins. Agnostic about UI Frameworks.
 
-Data Provider is a data provider _(surprise!)_ with states ands built-in cache for JavaScript apps.
+Data Provider is a data provider _(surprise!)_ with states and built-in cache for JavaScript apps.
 
 The main target of the library are front-end applications, but it could be used also in [Node.js][nodejs].
 
@@ -19,7 +19,7 @@ As its states are managed with [Redux][redux], you can take advantage of his lar
 
 You can use Data Provider with [React][react], or with any other view library. [Separated addons][addons] are available for that purpose, as [@data-provider/react][data-provider-react].
 
-Data Provider is __agnostic about data origins__, so it can be used to read data from a REST API, from localStorage, or from any other origin. Choose one of the [available addons][addons] depending of the type of the origin you want to read from, as [@data-provider/axios][data-provider-axios], or [@data-provider/browser-storage][data-provider-browser-storage].
+Data Provider is __agnostic about data origins__, so it can be used to read data from a REST API, from `localStorage`, or from any other origin. Choose one of the [available addons][addons] depending of the type of the origin you want to read from, as [`@data-provider/axios`][data-provider-axios], or [`@data-provider/browser-storage`][data-provider-browser-storage].
 
 It has a __light weight__, 4.2KB gzipped in UMD format _(you have to add the Redux weight to this)_, and addons usually are even lighter.
 
@@ -40,7 +40,7 @@ We have a website available to help you to learn to use Data Provider. There are
 
 ### Agnostic about data origins
 
-The Provider class provides the cache, state handler, etc., but not the "read" method. The "read" behavior is implemented by __different [Data Provider Origins addons][addons]__.
+The Provider class provides the cache, state handler, etc., but not the `read` method. The `read` behavior is implemented by __different [Data Provider Origins addons][addons]__.
 
 There are different origins addons available, such as __[Axios][data-provider-axios], [LocalStorage][data-provider-browser-storage], [Memory][data-provider-memory], etc.__ and building your own is so easy as extending the Provider class with a custom "readMethod".
 
@@ -116,11 +116,11 @@ export default RenderBooksTwice;
 
 ### Queryable
 
-Providers and selectors instances can be queried, which returns a new child instance with his own "query value".
+Providers and selectors instances can be queried, which returns a new child instance with its own `query value`.
 
 Each different child has a different cache, different state, etc.
 
-Different origins can use the "query" value for different purposes (API origins will normally use it for adding different params or query strings to the provider url, for example)
+Different origins can use the `queryValue` for different purposes (API origins will normally use it for adding different params or query strings to the provider url, for example)
 
 When the parent provider cache is clean, also the children is. _(For example, cleaning the cache of an API origin requesting to "/api/books", will also clean the cache for "/api/books?author=2")_
 
@@ -152,7 +152,7 @@ For example, the [@data-provider/react][data-provider-react] package __gives you
 
 It also provides __HOCs__ like "withData", "withLoading", etc. creating a wrapper component handling all the logic for you.
 
-__Optimized__, it takes care of reading the data and re-renders the component only when the provider desired props have changed. It also takes care of reading the data again every time the cache of the provider is invalidated.
+__Optimized__, it takes care of reading the data and re-renders the component only when the provider desired properties have changed. It also takes care of reading the data again every time the cache of the provider is invalidated.
 
 ```jsx
 import { useData, useLoading, useError } from "@data-provider/react";

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.js"],
-  // testMatch: ["<rootDir>/test/provider/clean-cache-throttle.js"],
+  // testMatch: ["<rootDir>/test/providers/config.js"],
 
   // The test environment that will be used for testing
   testEnvironment: "node",

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -13,8 +13,7 @@ import { storeManager } from "./storeManager";
 import {
   childId,
   eventNamespace,
-  removeFalsy,
-  ensureArray,
+  arrayWithoutFalsies,
   isFunction,
   isUndefined,
   ANY,
@@ -34,7 +33,10 @@ class Provider {
     this._emitChild = this._emitChild.bind(this);
     this._options = { ...defaultOptions, ...options };
     this._query = { ...query };
-    this._tags = removeFalsy(ensureArray(this._options.tags));
+    this._tags = [
+      ...arrayWithoutFalsies(this.baseTags),
+      ...arrayWithoutFalsies(this._options.tags),
+    ];
     this._children = new Map();
     this._queryMethods = new Map();
     this._queryMethodsParsers = new Map();
@@ -244,6 +246,10 @@ class Provider {
 
   get options() {
     return this._options;
+  }
+
+  get tags() {
+    return this._tags;
   }
 
   // Methods to be used for testing

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -9,7 +9,14 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
-import { CLEAN_CACHE, isFunction, isArray, isPromise, ensureArray } from "./helpers";
+import {
+  SELECTORS_TAG,
+  CLEAN_CACHE,
+  isFunction,
+  isArray,
+  isPromise,
+  ensureArray,
+} from "./helpers";
 import Provider from "./Provider";
 import CatchDependency from "./CatchDependency";
 
@@ -228,6 +235,12 @@ class SelectorBase extends Provider {
     } else {
       this._cleanCaches(this._resolvedDependencies, options);
     }
+  }
+
+  // Define base tag
+
+  get baseTags() {
+    return SELECTORS_TAG;
   }
 
   // Methods to be used for testing

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,6 +24,7 @@ export const defaultOptions = {
   cleanCacheThrottle: 0,
 };
 
+export const SELECTORS_TAG = "selector";
 export const INIT = "init";
 export const CLEAN_CACHE = "cleanCache";
 export const RESET_STATE = "resetState";

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,6 +88,10 @@ export function removeFalsy(array) {
   return array.filter((el) => !!el);
 }
 
+export function arrayWithoutFalsies(els) {
+  return removeFalsy(ensureArray(els));
+}
+
 export function message(text) {
   return `@data-provider/core: ${text}`;
 }

--- a/src/providers.js
+++ b/src/providers.js
@@ -55,6 +55,10 @@ export class ProvidersHandler {
     return this._run("cleanCache", options);
   }
 
+  cleanDependenciesCache(options) {
+    return this._run("cleanDependenciesCache", options);
+  }
+
   resetState() {
     return this._run("resetState");
   }
@@ -172,6 +176,10 @@ export class Providers {
 
   cleanCache(options) {
     return this._allProviders.cleanCache(options);
+  }
+
+  cleanDependenciesCache(options) {
+    return this._allProviders.cleanDependenciesCache(options);
   }
 
   resetState() {

--- a/test/providers/cleanDependenciesCache.js
+++ b/test/providers/cleanDependenciesCache.js
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 Javier Brea
+Copyright 2019 XbyOrange
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+*/
+
+const sinon = require("sinon");
+
+const { Provider, providers, Selector } = require("../../src/index");
+
+describe("providers handler cleanDependenciesCache method", () => {
+  let sandbox;
+  let fooProvider;
+  let fooProvider2;
+  let fooProvider3;
+  let fooProvider4;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    fooProvider = new Provider("foo-1", { tags: "tag-1" });
+    fooProvider2 = new Provider("foo-2", { tags: ["tag-2", "tag-3"] });
+    fooProvider3 = new Provider("foo-3", { tags: "tag-3" });
+    fooProvider4 = new Selector(fooProvider, fooProvider2, () => {}, {
+      id: "foo-4",
+      tags: "tag-2",
+    });
+
+    sandbox.spy(fooProvider, "cleanDependenciesCache");
+    sandbox.spy(fooProvider2, "cleanDependenciesCache");
+    sandbox.spy(fooProvider3, "cleanDependenciesCache");
+    sandbox.spy(fooProvider4, "cleanDependenciesCache");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    providers.clear();
+  });
+
+  describe("when applied to all providers", () => {
+    it("should call to cleanDependenciesCache method of all providers", () => {
+      providers.cleanDependenciesCache();
+
+      expect(fooProvider.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider2.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider3.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider4.cleanDependenciesCache.callCount).toEqual(1);
+    });
+
+    it("should pass options to providers cleanDependenciesCache method", () => {
+      providers.cleanDependenciesCache({ force: true });
+
+      expect(fooProvider.cleanDependenciesCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider2.cleanDependenciesCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider3.cleanDependenciesCache.getCall(0).args[0]).toEqual({ force: true });
+      expect(fooProvider4.cleanDependenciesCache.getCall(0).args[0]).toEqual({ force: true });
+    });
+  });
+
+  describe("when used with getById", () => {
+    it("should call to cleanDependenciesCache method only of selected providers", () => {
+      providers.getById("foo-2").cleanDependenciesCache();
+
+      expect(fooProvider.cleanDependenciesCache.callCount).toEqual(0);
+      expect(fooProvider2.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider3.cleanDependenciesCache.callCount).toEqual(0);
+      expect(fooProvider4.cleanDependenciesCache.callCount).toEqual(0);
+    });
+  });
+
+  describe("when used with getByTag", () => {
+    it("should call to cleanDependenciesCache method only of selected providers", () => {
+      providers.getByTag("tag-2").cleanDependenciesCache();
+
+      expect(fooProvider.cleanDependenciesCache.callCount).toEqual(0);
+      expect(fooProvider2.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider3.cleanDependenciesCache.callCount).toEqual(0);
+      expect(fooProvider4.cleanDependenciesCache.callCount).toEqual(1);
+    });
+
+    it("should call to cleanDependenciesCache method of all selected providers", () => {
+      providers.getByTag("tag-3").cleanDependenciesCache();
+
+      expect(fooProvider.cleanDependenciesCache.callCount).toEqual(0);
+      expect(fooProvider2.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider3.cleanDependenciesCache.callCount).toEqual(1);
+      expect(fooProvider4.cleanDependenciesCache.callCount).toEqual(0);
+    });
+  });
+});

--- a/test/providers/config.js
+++ b/test/providers/config.js
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 const sinon = require("sinon");
 
-const { Provider, providers } = require("../../src/index");
+const { Provider, Selector, providers } = require("../../src/index");
 const { defaultOptions } = require("../../src/helpers");
 
 describe("providers handler config method", () => {
@@ -331,6 +331,66 @@ describe("providers handler config method", () => {
         });
 
         expect(fooProvider6.tags).toEqual(["tag-3", "tag-5", "tag-6"]);
+      });
+    });
+  });
+
+  describe("selectors tag", () => {
+    let fooSelector;
+    let fooSelector2;
+    beforeEach(() => {
+      fooSelector = new Selector(() => {});
+      fooSelector2 = new Selector(() => {}, { tags: "tag-5" });
+    });
+
+    describe("tags getter", () => {
+      it("should return selector tag extended with tags option", () => {
+        expect(fooSelector.tags).toEqual(["selector"]);
+        expect(fooSelector2.tags).toEqual(["selector", "tag-5"]);
+      });
+    });
+
+    describe("when applied to groups of providers using getByTag method", () => {
+      it("should apply config to all providers in group", () => {
+        providers.getByTag("selector").config({
+          foo: "foo",
+        });
+
+        expect(fooSelector.options.foo).toEqual("foo");
+        expect(fooSelector2.options.foo).toEqual("foo");
+      });
+
+      it("should not apply config to non-belonging selectors", () => {
+        providers.getByTag("tag-5").config({
+          foo: "foo",
+        });
+
+        expect(fooSelector2.options.foo).toEqual("foo");
+        expect(fooSelector.options.foo).toEqual(undefined);
+      });
+
+      it("should extend previously defined configuration when creating source containing tag", () => {
+        providers.getByTag("selector").config({
+          foo: "foo",
+          foo2: "foo2",
+        });
+
+        const fooSelector3 = new Selector(() => {}, { tags: ["tag-5", "tag-6"] });
+
+        providers.getByTag("tag-6").config({
+          foo2: "new-foo2",
+          foo3: "foo3",
+        });
+
+        expect(fooSelector3.options).toEqual({
+          ...defaultOptions,
+          foo: "foo",
+          foo2: "new-foo2",
+          foo3: "foo3",
+          tags: ["tag-5", "tag-6"],
+        });
+
+        expect(fooSelector3.tags).toEqual(["selector", "tag-5", "tag-6"]);
       });
     });
   });


### PR DESCRIPTION
### Added
- feat: Allow defining baseTags property in addons. Will be extended with "tags" option when instantiated for calculating provider tags. (#143)
- feat: Add tags getter
- feat: Add "selector" base tag to selectors (#163)
- feat: Add `cleanDependenciesCache` method to `providers` handler (#164)

### Fixed
- docs(readme): Fix typos