### PR TITLE
Release v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
-- fix: Selector cleanDependenciesCache method was cleaning only in progress dependencies if the selector read was in progress, so previous dependencies were not being cleaned
 ### Removed
+
+## [2.9.1] - 2021-01-04
+
+### Fixed
+- fix: Selector cleanDependenciesCache method was cleaning only in progress dependencies if the selector read was in progress, so previous dependencies were not being cleaned
 
 ## [2.9.0] - 2020-12-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- fix: Selector cleanDependenciesCache method was cleaning only in progress dependencies if the selector read was in progress, so previous dependencies were not being cleaned
 ### Removed
 
 ## [2.9.0] - 2020-12-27

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Async Data Provider agnostic about data origins",
   "keywords": [
     "data",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=data-provider
 sonar.projectKey=data-provider-core
-sonar.projectVersion=2.9.0
+sonar.projectVersion=2.9.1
 
 sonar.sources=src,test
 sonar.exclusions=node_modules/**

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -230,11 +230,11 @@ class SelectorBase extends Provider {
   }
 
   _unthrottledCleanDependenciesCache(options = {}) {
-    if (this._inProgressDependencies.size > 0) {
-      this._cleanCaches(Array.from(this._inProgressDependencies), options);
-    } else {
-      this._cleanCaches(this._resolvedDependencies, options);
-    }
+    const dependenciesToClean = new Set(this._resolvedDependencies);
+    this._inProgressDependencies.forEach((dependency) => {
+      dependenciesToClean.add(dependency);
+    });
+    this._cleanCaches(Array.from(dependenciesToClean), options);
   }
 
   // Define base tag

--- a/test/selector/cache-dependencies-clean.js
+++ b/test/selector/cache-dependencies-clean.js
@@ -113,6 +113,39 @@ describe("Selector when cleanDependenciesCache method is called", () => {
     expect(dependency3.cleanDependenciesCache.callCount).toEqual(1);
   });
 
+  it("should call to clean all dependendencies cache, even when read is in progress", async () => {
+    let readSelectorPromise;
+    expect.assertions(3);
+    sandbox.spy(dependency1, "cleanDependenciesCache");
+    sandbox.spy(dependency2, "cleanDependenciesCache");
+    sandbox.spy(dependency3, "cleanDependenciesCache");
+    await selector.read();
+    dependency3.cleanCache();
+    readSelectorPromise = selector.read();
+    selector.cleanDependenciesCache();
+    await readSelectorPromise;
+    expect(dependency1.cleanDependenciesCache.callCount).toEqual(1);
+    expect(dependency2.cleanDependenciesCache.callCount).toEqual(1);
+    expect(dependency3.cleanDependenciesCache.callCount).toEqual(1);
+  });
+
+  it("should return last data returned by all dependencies, even when read is in progress", async () => {
+    let readSelectorPromise;
+    expect.assertions(2);
+    results = {
+      dependency1: ["foo", "foo2"],
+      dependency2: ["foo3", "foo4"],
+      dependency3: ["foo5", "foo6"],
+    };
+    const result = await selector.read();
+    expect(result).toEqual(["foo", "foo3", "foo5"]);
+    dependency3.cleanCache();
+    readSelectorPromise = selector.read();
+    selector.cleanDependenciesCache();
+    await readSelectorPromise;
+    expect(selector.state.data).toEqual(["foo2", "foo4", "foo6"]);
+  });
+
   it("should call to clean all dependendencies cache except that in the except option", async () => {
     expect.assertions(3);
     sandbox.spy(dependency1, "cleanDependenciesCache");


### PR DESCRIPTION
### Fixed
- fix: Selector cleanDependenciesCache method was cleaning only in progress dependencies if the selector read was in progress, so previous dependencies were not being cleaned

